### PR TITLE
Update CRISPRcleanR.R

### DIFF
--- a/R/CRISPRcleanR.R
+++ b/R/CRISPRcleanR.R
@@ -2013,10 +2013,6 @@ ccr.cleanChrm <- function(
     verbose = verbose
   )
 
-  if (!display) {
-    saveTO <- NULL
-  }
-
   if (length(saveTO)) {
     display <- TRUE
     path <- paste0(saveTO, label, "/")
@@ -2024,6 +2020,10 @@ ccr.cleanChrm <- function(
       dir.create(path)
     }
     pdf(paste0(path, CHR, ".pdf"), width = 7.5, height = 7.5)
+  }
+  
+  if (!display) {
+    saveTO <- NULL
   }
 
   if (display) {


### PR DESCRIPTION
Bug: when display is set to FALSE in ccr.GWclean and an output path in which to save figures is provided this path is set to NULL in  ccr.cleanChrm function. 

This change fixes the issue by moving the display value check after the path length check.